### PR TITLE
Remove unused package reference to ReactiveUI

### DIFF
--- a/src/AvaloniaHex/AvaloniaHex.csproj
+++ b/src/AvaloniaHex/AvaloniaHex.csproj
@@ -20,7 +20,6 @@
 
     <ItemGroup>
       <PackageReference Include="Avalonia" Version="11.0.10" />
-      <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.10" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Unless i"m missing something, there does not appears to be a need to pull in the ReactiveUI package. 