### PR TITLE
Fix DivideByZeroException

### DIFF
--- a/src/AvaloniaHex/Rendering/HexView.cs
+++ b/src/AvaloniaHex/Rendering/HexView.cs
@@ -580,7 +580,7 @@ public class HexView : Control, ILogicalScrollable
     /// <returns><c>true</c> if the scroll offset has changed, <c>false</c> otherwise.</returns>
     public bool BringIntoView(BitLocation location)
     {
-        if (location.ByteIndex >= Document?.Length + 1 || FullyVisibleRange.Contains(location))
+        if (location.ByteIndex >= Document?.Length + 1 || FullyVisibleRange.Contains(location) || ActualBytesPerLine == 0)
             return false;
 
         ulong firstLineIndex = FullyVisibleRange.Start.ByteIndex / (ulong) ActualBytesPerLine;


### PR DESCRIPTION
I am submitting a pull request for a solution to a zero division exception that has been occurring.

```
System.DivideByZeroException: Arg_DivideByZero
at AvaloniaHex.Rendering.HexView.BringIntoView(BitLocation location)
at AvaloniaHex.Editing.Caret.OnLocationChanged()
at AvaloniaHex.Editing.Caret.set_Location(BitLocation value)
at AvaloniaHex.HexEditor.HexViewOnDocumentChanged(Object sender, DocumentChangedEventArgs e)
at AvaloniaHex.Rendering.HexView.OnDocumentChanged(DocumentChangedEventArgs e)
at AvaloniaHex.Rendering.HexView.OnDocumentChanged(HexView view, AvaloniaPropertyChangedEventArgs arg2)
at Avalonia.AvaloniaObjectExtensions.ClassHandlerObserver`1.OnNext(AvaloniaPropertyChangedEventArgs value)
at Avalonia.Reactive.LightweightObservableBase`1.PublishNext(T value)
at Avalonia.Reactive.LightweightSubject`1.OnNext(T value)
at Avalonia.AvaloniaProperty`1.NotifyChanged(AvaloniaPropertyChangedEventArgs`1 e)
at Avalonia.AvaloniaObject.RaisePropertyChanged[T](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority, Boolean isEffectiveValue)
at Avalonia.PropertyStore.EffectiveValue`1.NotifyValueChanged(ValueStore owner, StyledProperty`1 property, T oldValue)
at Avalonia.PropertyStore.EffectiveValue`1.SetAndRaiseCore(ValueStore owner, StyledProperty`1 property, T value, BindingPriority priority, Boolean isOverriddenCurrentValue, Boolean isCoercedDefaultValue)
at Avalonia.PropertyStore.EffectiveValue`1.SetLocalValueAndRaise(ValueStore owner, StyledProperty`1 property, T value)
at Avalonia.PropertyStore.ValueStore.SetLocalValue[T](StyledProperty`1 property, T value)
at Avalonia.PropertyStore.ValueStore.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority)
at Avalonia.AvaloniaObject.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority)
at AvaloniaHex.Rendering.HexView.set_Document(IBinaryDocument value)
at AvaloniaHex.HexEditor.OnDocumentChanged(HexEditor sender, AvaloniaPropertyChangedEventArgs`1 e)
at Avalonia.AvaloniaObjectExtensions.ClassHandlerObserver`2.OnNext(AvaloniaPropertyChangedEventArgs`1 value)
at Avalonia.Reactive.LightweightObservableBase`1.PublishNext(T value)
at Avalonia.Reactive.LightweightSubject`1.OnNext(T value)
at Avalonia.AvaloniaProperty`1.NotifyChanged(AvaloniaPropertyChangedEventArgs`1 e)
at Avalonia.AvaloniaObject.RaisePropertyChanged[T](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority, Boolean isEffectiveValue)
at Avalonia.PropertyStore.EffectiveValue`1.NotifyValueChanged(ValueStore owner, StyledProperty`1 property, T oldValue)
at Avalonia.PropertyStore.EffectiveValue`1.SetAndRaiseCore(ValueStore owner, StyledProperty`1 property, T value, BindingPriority priority, Boolean isOverriddenCurrentValue, Boolean isCoercedDefaultValue)
at Avalonia.PropertyStore.EffectiveValue`1.SetLocalValueAndRaise(ValueStore owner, StyledProperty`1 property, T value)
at Avalonia.PropertyStore.ValueStore.SetLocalValue[T](StyledProperty`1 property, T value)
at Avalonia.PropertyStore.ValueStore.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority)
at Avalonia.AvaloniaObject.SetValue[T](StyledProperty`1 property, T value, BindingPriority priority)
at AvaloniaHex.HexEditor.set_Document(IBinaryDocument value)
```