### PR TITLE
Improve HexView scroll info

### DIFF
--- a/src/AvaloniaHex/HexEditor.cs
+++ b/src/AvaloniaHex/HexEditor.cs
@@ -421,13 +421,6 @@ public class HexEditor : TemplatedControl
         }
     }
 
-    /// <inheritdoc />
-    protected override void OnSizeChanged(SizeChangedEventArgs e)
-    {
-        HexView.BringIntoView(Caret.Location);
-        base.OnSizeChanged(e);
-    }
-
     /// <summary>
     /// Copies the currently selected text to the clipboard.
     /// </summary>

--- a/src/AvaloniaHex/Rendering/HexView.cs
+++ b/src/AvaloniaHex/Rendering/HexView.cs
@@ -831,6 +831,8 @@ public class HexView : Control, ILogicalScrollable
             return false;
         }
 
+        // FullyVisibleRange and ActualBytesPerLine are calculated in Arrange. These values
+        // might be stale (IsArrangeValid == false). Make sure that the layout is up to date.
         UpdateLayout();
 
         ulong firstLineIndex = FullyVisibleRange.Start.ByteIndex / (ulong) ActualBytesPerLine;


### PR DESCRIPTION
This PR improves the `IScrollable` implementation in `HexView`.

Improvements:

- FIX: The vertical scroll bar thumb size is now kept proportional to the viewport size. For example, when the hex editor contains ~3 pages of content then the scroll bar thumb should be ~1/3 of the scroll bar. Previously, the thumb always had the minimum size. (See example screenshots here: #30)
- When resizing the window (with `Bytes Per Line = Adjust to Width`), the top-left byte is treated as an "anchor" for scrolling. The `HexView` will try to keep the anchor byte always on the first visible line. This ensures that the visible contents remains as stable as possible. For example, when you grow the window and then shrink the window back to its original size, it will show exactly the same content as before.
- During resizing `BringIntoView` is no longer called for the caret. When the windows shrinks, the caret may end up below the visible lines. This is consistent with regular text editors. This ensure that the visible content remains stable.
- I tried to minimize the `ILogicalScrollable.RaiseScrollInvalidated` calls to avoid any unnecessary updates/loops.
- FIX: `BringIntoView` should call `UpdateLayout`, otherwise it may fail due to missing layout information.
- FIX: `ArgumentException` ("End location is smaller than start location.") in `HexView.UpdateVisualLines` when resizing the main window to minimum size. (Reproducible in original demo.)
- I added 1 line of virtual space at the bottom of the document for aesthetics, when scrolling all to the end. Currently it is a constant (`HexView.VirtualSpace`), but it could be made adjustable.

Hope that all makes sense. Let me know if I need to provide more info. Looking forward to your feedback. (Feel free to disagree with any of my changes.)