### PR TITLE
Upgrade to Avalonia 12

### DIFF
--- a/examples/AvaloniaHex.Demo/AvaloniaHex.Demo.csproj
+++ b/examples/AvaloniaHex.Demo/AvaloniaHex.Demo.csproj
@@ -2,27 +2,29 @@
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <Nullable>enable</Nullable>
-        <!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
+        <!--Avalonia doesn't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
         <TrimMode>copyused</TrimMode>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     </PropertyGroup>
     <ItemGroup>
-        <None Remove=".gitignore"/>
+        <None Remove=".gitignore" />
     </ItemGroup>
     <ItemGroup>
         <!--This helps with theme dll-s trimming.
         If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
         https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
-        <TrimmableAssembly Include="Avalonia.Themes.Fluent"/>
-        <TrimmableAssembly Include="Avalonia.Themes.Default"/>
+        <TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+        <TrimmableAssembly Include="Avalonia.Themes.Default" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.11" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.11" />
-        <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.11" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.11" />
+        <PackageReference Include="Avalonia" Version="12.0.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
+        <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.0" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+
+        <!-- Condition below is needed to remove Avalonia Dev Tools from build output in Release configuration. -->
+        <!--<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />-->
+
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\src\AvaloniaHex\AvaloniaHex.csproj" />

--- a/examples/AvaloniaHex.Demo/InputDialog.axaml.cs
+++ b/examples/AvaloniaHex.Demo/InputDialog.axaml.cs
@@ -1,8 +1,6 @@
 using System;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 
 namespace AvaloniaHex.Demo;
 
@@ -25,10 +23,10 @@ public partial class InputDialog : Window
         set => InputTextBox.Text = value;
     }
 
-    public string? Watermark
+    public string? PlaceholderText
     {
-        get => InputTextBox.Watermark;
-        set => InputTextBox.Watermark = value;
+        get => InputTextBox.PlaceholderText;
+        set => InputTextBox.PlaceholderText = value;
     }
 
     public Predicate<string?> IsValid

--- a/examples/AvaloniaHex.Demo/MainWindow.axaml.cs
+++ b/examples/AvaloniaHex.Demo/MainWindow.axaml.cs
@@ -456,7 +456,7 @@ namespace AvaloniaHex.Demo
             var dialog = new InputDialog
             {
                 Prompt = $"Fill {range} with byte sequence (hex):",
-                Watermark = "00 01 02 ...",
+                PlaceholderText = "00 01 02 ...",
                 IsValid = static s=> TryGetHexString(s) is not null,
             };
 

--- a/src/AvaloniaHex/AvaloniaHex.csproj
+++ b/src/AvaloniaHex/AvaloniaHex.csproj
@@ -21,11 +21,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia" Version="11.3.10" />
+      <PackageReference Include="Avalonia" Version="12.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/AvaloniaHex/HexEditor.cs
+++ b/src/AvaloniaHex/HexEditor.cs
@@ -550,7 +550,7 @@ public class HexEditor : TemplatedControl
     }
 
     /// <inheritdoc />
-    protected override void OnGotFocus(GotFocusEventArgs e)
+    protected override void OnGotFocus(FocusChangedEventArgs e)
     {
         base.OnGotFocus(e);
         HexView.Focus();

--- a/src/AvaloniaHex/Rendering/HexView.cs
+++ b/src/AvaloniaHex/Rendering/HexView.cs
@@ -295,6 +295,10 @@ public class HexView : Control, ILogicalScrollable
         private set;
     }
 
+    bool IScrollable.CanHorizontallyScroll => ((ILogicalScrollable) this).CanHorizontallyScroll;
+
+    bool IScrollable.CanVerticallyScroll => ((ILogicalScrollable) this).CanVerticallyScroll;
+
     bool ILogicalScrollable.CanHorizontallyScroll { get; set; } = false;
 
     bool ILogicalScrollable.CanVerticallyScroll { get; set; } = true;

--- a/test/AvaloniaHex.Tests/AvaloniaHex.Tests.csproj
+++ b/test/AvaloniaHex.Tests/AvaloniaHex.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Upgrade project to Avalonia 12.

Updated dependencies:
- Avalonia 11.3.11 → 12.0.1
- Avalonia.Diagnostics 11.3.11 → Removed. See [Avalonia.Diagnostics package removed](https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#avaloniadiagnostics-package-removed).
- AvaloniaUI.DiagnosticsSupport added but commented out. Requires Avalonia Plus subscription.
- Microsoft.NET.Test.Sdk 17.14.1 → 18.4.0
- xUnit 2 → xUnit 3

I fixed the [breaking changes](https://docs.avaloniaui.net/docs/avalonia12-breaking-changes).
Everything seems to be working as expected.

I did not bump the AvaloniaHex version or the copyright years (2025 → 2026).

Hope this helps. Looking forward to the next release.